### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTestData.cs
+++ b/YamlDotNet.Test/Spec/SpecTestData.cs
@@ -97,6 +97,18 @@ namespace YamlDotNet.Test.Spec
 
             if (!string.IsNullOrEmpty(fixturesPath))
             {
+                // Normalize the path to resolve any relative components
+                fixturesPath = Path.GetFullPath(fixturesPath);
+
+                // Define a safe base directory (e.g., the project's root directory)
+                var safeBaseDirectory = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), ".."));
+
+                // Ensure the path is within the safe base directory
+                if (!fixturesPath.StartsWith(safeBaseDirectory + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+                {
+                    throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' is not within the allowed base directory!");
+                }
+
                 if (!Directory.Exists(fixturesPath))
                 {
                     throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' does not exist!");


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/YamlDotNet/security/code-scanning/2](https://github.com/MjrTom/YamlDotNet/security/code-scanning/2)

To fix the issue, we need to validate the user-provided environment variable `YAMLDOTNET_SPEC_SUITE_DIR` to ensure it points to a safe and expected directory. This can be achieved by:
1. Normalizing the path using `Path.GetFullPath` to resolve any relative components like `..`.
2. Verifying that the resolved path is within a predefined safe base directory.
3. Rejecting the input if it does not meet these criteria.

The fix will involve modifying the `GetTestFixtureDirectory` method to include these validation steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
