### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTestData.cs
+++ b/YamlDotNet.Test/Spec/SpecTestData.cs
@@ -106,7 +106,8 @@ namespace YamlDotNet.Test.Spec
                     var baseDirectory = Path.GetFullPath("/safe/base/directory");
 
                     // Ensure the path is within the safe base directory
-                    if (!fixturesPath.StartsWith(baseDirectory + Path.DirectorySeparatorChar))
+                    var relativePath = Path.GetRelativePath(baseDirectory, fixturesPath);
+                    if (relativePath.StartsWith("..") || Path.IsPathRooted(relativePath))
                     {
                         throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' is not within the allowed base directory!");
                     }

--- a/YamlDotNet.Test/Spec/SpecTestData.cs
+++ b/YamlDotNet.Test/Spec/SpecTestData.cs
@@ -97,12 +97,31 @@ namespace YamlDotNet.Test.Spec
 
             if (!string.IsNullOrEmpty(fixturesPath))
             {
-                if (!Directory.Exists(fixturesPath))
+                try
                 {
-                    throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' does not exist!");
-                }
+                    // Normalize the path to resolve any relative components
+                    fixturesPath = Path.GetFullPath(fixturesPath);
 
-                return fixturesPath;
+                    // Define a safe base directory
+                    var baseDirectory = Path.GetFullPath("/safe/base/directory");
+
+                    // Ensure the path is within the safe base directory
+                    if (!fixturesPath.StartsWith(baseDirectory + Path.DirectorySeparatorChar))
+                    {
+                        throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' is not within the allowed base directory!");
+                    }
+
+                    if (!Directory.Exists(fixturesPath))
+                    {
+                        throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' does not exist!");
+                    }
+
+                    return fixturesPath;
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception("Invalid path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR': " + ex.Message);
+                }
             }
 
             // In Microsoft.NET.Test.Sdk v15.0.0, the current working directory


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/YamlDotNet/security/code-scanning/1](https://github.com/MjrTom/YamlDotNet/security/code-scanning/1)

To fix the issue, we need to validate the `fixturesPath` value before using it. Specifically:
1. Normalize the path using `Path.GetFullPath` to resolve any relative components like `..`.
2. Ensure that the resolved path is within a safe, predefined base directory to prevent path traversal attacks.
3. Reject the input if it does not meet these criteria.

The fix will involve modifying the `GetTestFixtureDirectory` method to include these validation steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
