### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/YamlDotNet.Test/Spec/SpecTestData.cs
+++ b/YamlDotNet.Test/Spec/SpecTestData.cs
@@ -97,33 +97,22 @@ namespace YamlDotNet.Test.Spec
 
             if (!string.IsNullOrEmpty(fixturesPath))
             {
-                // Normalize the path to resolve any relative components
-                fixturesPath = Path.GetFullPath(fixturesPath);
-
-                // Define a safe base directory (e.g., the project's root directory)
-                var safeBaseDirectory = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), ".."));
-
-                // Ensure the path is within the safe base directory
-                if (!fixturesPath.StartsWith(safeBaseDirectory + Path.DirectorySeparatorChar, StringComparison.Ordinal))
-                {
-                    throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' is not within the allowed base directory!");
-                }
-
-                if (!Directory.Exists(fixturesPath))
+                try
                 {
                     // Normalize the path to resolve any relative components
                     fixturesPath = Path.GetFullPath(fixturesPath);
 
-                    // Define a safe base directory
-                    var baseDirectory = Path.GetFullPath("/safe/base/directory");
+                    // Define a safe base directory (e.g., the project's root directory)
+                    var safeBaseDirectory = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), ".."));
 
                     // Ensure the path is within the safe base directory
-                    var relativePath = Path.GetRelativePath(baseDirectory, fixturesPath);
+                    var relativePath = Path.GetRelativePath(safeBaseDirectory, fixturesPath);
                     if (relativePath.StartsWith("..") || Path.IsPathRooted(relativePath))
                     {
                         throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' is not within the allowed base directory!");
                     }
 
+                    // Ensure the directory exists
                     if (!Directory.Exists(fixturesPath))
                     {
                         throw new Exception("Path set as environment variable 'YAMLDOTNET_SPEC_SUITE_DIR' does not exist!");


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/YamlDotNet/security/code-scanning/3](https://github.com/MjrTom/YamlDotNet/security/code-scanning/3)

To fix the issue, we need to simplify and strengthen the validation logic for `fixturesPath`:
1. Normalize the path using `Path.GetFullPath` to resolve any relative components.
2. Define a single safe base directory and ensure that `fixturesPath` resides within it using `Path.GetRelativePath` or a similar method.
3. Remove redundant and convoluted checks to make the validation logic clear and robust.
4. Throw an exception if the path is invalid or does not exist.

The changes will be made in the `GetTestFixtureDirectory` method, specifically in the validation logic for `fixturesPath`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
